### PR TITLE
Update Hadoop-related libraries to develop on Apple Silicon Mac

### DIFF
--- a/shared/Dockerfile
+++ b/shared/Dockerfile
@@ -1,17 +1,30 @@
 FROM public.ecr.aws/amazoncorretto/amazoncorretto:11 as hadoop-libs
-ARG HADOOP_VERSION=3.0.3
+ARG HADOOP_VERSION=3.3.4
 
 RUN yum install -y tar gzip
 
 WORKDIR /tmp
-# TODO: Use dlcdn.apache.org after upgrading to recent versions
-RUN curl -sSfO "https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz{,.sha256,.asc}"
+RUN curl -sSfO "https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz{,.sha512,.asc}"
 RUN curl -sSf https://downloads.apache.org/hadoop/common/KEYS | gpg --import
-RUN sha256sum -c hadoop-${HADOOP_VERSION}.tar.gz.sha256
+RUN sha512sum -c hadoop-${HADOOP_VERSION}.tar.gz.sha512
 RUN gpg --verify hadoop-${HADOOP_VERSION}.tar.gz.asc
 RUN tar xf hadoop-${HADOOP_VERSION}.tar.gz && mv hadoop-${HADOOP_VERSION} hadoop
 
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:11 as libisal
+ARG LIBISAL_VERSION=2.30.0
+ARG LIBISAL_SHA512SUM=d3ecfb7326097534b06a74b584100336509525ae7cadc6112d0c27e3d8704f3810e18f583d3cc33fa266bfec96db023607622b22ddbf17988ec4bf1bb3b3b9b2
+
+RUN yum install -y tar gzip autoconf automake libtool make nasm
+
+WORKDIR /tmp
+RUN curl -sSfLO https://github.com/intel/isa-l/archive/refs/tags/v${LIBISAL_VERSION}.tar.gz
+RUN echo ${LIBISAL_SHA512SUM} v${LIBISAL_VERSION}.tar.gz | sha512sum -c -
+RUN tar xf v${LIBISAL_VERSION}.tar.gz
+WORKDIR /tmp/isa-l-${LIBISAL_VERSION}
+RUN ./autogen.sh && ./configure --prefix=/usr --libdir=/usr/lib64 && make install
+
 FROM public.ecr.aws/amazoncorretto/amazoncorretto:11
 
-RUN yum install -y snappy && yum clean all && rm -rf /var/cache/yum
+RUN yum install -y libzstd && yum clean all && rm -rf /var/cache/yum
 COPY --from=hadoop-libs /tmp/hadoop/lib/native/lib*.so /usr/lib64/
+COPY --from=libisal /usr/lib64/libisal.so.2 /usr/lib64/

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -4,8 +4,9 @@ plugins {
 
 dependencies {
     compile group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: '1.3.2'
-    compile group: "org.apache.parquet", name: "parquet-hadoop", version: "1.9.0"
-    compile group: "org.apache.hadoop", name: "hadoop-common", version: "2.7.3"
+    compile group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.12.3'
+    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4'
+    compile group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.4'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.7'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.7'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.438'


### PR DESCRIPTION
org.xerial.snappy needs to be updated to support native libraries for Apple Silicon Mac.