### PR TITLE
stream: Discard too past or too future staging objects

### DIFF
--- a/stream/src/main/java/com/cookpad/prism/stream/ParquetConverter.java
+++ b/stream/src/main/java/com/cookpad/prism/stream/ParquetConverter.java
@@ -136,7 +136,7 @@ public class ParquetConverter implements StagingObjectHandler {
     }
 
     static final long ACCEPTABLE_PAST_DAYS = 21;
-    static final long ACCEPTABLE_FUTURE_DAYS = 14;
+    static final long ACCEPTABLE_FUTURE_DAYS = 3;
 
     static boolean isAcceptable(LocalDate partitionDate, LocalDateTime now) {
         LocalDate min = now.minusDays(ACCEPTABLE_PAST_DAYS).toLocalDate();

--- a/stream/src/main/java/com/cookpad/prism/stream/ParquetConverter.java
+++ b/stream/src/main/java/com/cookpad/prism/stream/ParquetConverter.java
@@ -128,7 +128,7 @@ public class ParquetConverter implements StagingObjectHandler {
                 } else {
                     prismObjectStore.putLiveObjectFile(dt, stagingObject.getId(), file);
                 }
-                if (isAcceptableDelay(dt, now)) {
+                if (isMergeableDelay(dt, now)) {
                     LocalDateTime scheduleTime = table.scheduleTime(now);
                     this.mergeJobMapper.enqueue(partition.getId(), scheduleTime);
                 }
@@ -138,14 +138,14 @@ public class ParquetConverter implements StagingObjectHandler {
         }
     }
 
-    static final long ACCEPTABLE_DELAY_DAYS = 14;
+    static final long MERGEABLE_DELAY_DAYS = 14;
 
-    static boolean isAcceptableDelay(LocalDate partitionDate, LocalDateTime now) {
+    static boolean isMergeableDelay(LocalDate partitionDate, LocalDateTime now) {
         // +1 day as max timezone offset
         // +1 hour for spare (processing delay, S3 event delay, etc)
-        LocalDate minAcceptableDate = now.minusDays(ACCEPTABLE_DELAY_DAYS + 1).minusHours(1).toLocalDate();
-        LocalDate maxAcceptableDate = now.plusDays(1).plusHours(1).toLocalDate();
-        return (partitionDate.isEqual(minAcceptableDate) || partitionDate.isAfter(minAcceptableDate))
-            && (partitionDate.isEqual(maxAcceptableDate) || partitionDate.isBefore(maxAcceptableDate));
+        LocalDate minMergeableDate = now.minusDays(MERGEABLE_DELAY_DAYS + 1).minusHours(1).toLocalDate();
+        LocalDate maxMergeableDate = now.plusDays(1).plusHours(1).toLocalDate();
+        return (partitionDate.isEqual(minMergeableDate) || partitionDate.isAfter(minMergeableDate))
+            && (partitionDate.isEqual(maxMergeableDate) || partitionDate.isBefore(maxMergeableDate));
     }
 }

--- a/stream/src/main/java/com/cookpad/prism/stream/ParquetConverter.java
+++ b/stream/src/main/java/com/cookpad/prism/stream/ParquetConverter.java
@@ -62,9 +62,6 @@ public class ParquetConverter implements StagingObjectHandler {
     private final SchemaBuilder schemaBuilder;
     private final Clock clock;
 
-    // FIXME: fixed lower bound: 2018-01-01 (inclusive)
-    static final LocalDate PARTITION_DATE_LOWER_BOUND = LocalDate.of(2018, 1, 1);
-
     @Override
     public void handleStagingObject(@NonNull PrismStagingObject stagingObject, @NonNull StagingObjectAttributes attrs, @NonNull OneToMany<PacketStream, StreamColumn> packetStreamWithColumns, @NonNull PrismTable table) throws UnknownObjectException {
         Schema schema;
@@ -74,6 +71,7 @@ public class ParquetConverter implements StagingObjectHandler {
             throw new UnknownObjectException(e);
         }
         TempFile.Factory tempFileFactory = new TempFile.Factory("prism-stream-", ".parquet");
+        LocalDateTime now = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
         try (PartitionCollector partitionCollector = new PartitionCollector()) {
             ArrayList<DateAttachedRecord> recordsBuffer = new ArrayList<>(80000);
             try (
@@ -88,7 +86,7 @@ public class ParquetConverter implements StagingObjectHandler {
                 long discarded = 0;
                 while ((record = recordReader.read()) != null) {
                     var dt = record.getPartitionDate();
-                    if (dt.isAfter(PARTITION_DATE_LOWER_BOUND) || dt.isEqual(PARTITION_DATE_LOWER_BOUND)) {
+                    if (isAcceptable(dt, now)) {
                         recordsBuffer.add(record);
                     }
                     else {
@@ -96,7 +94,7 @@ public class ParquetConverter implements StagingObjectHandler {
                     }
                 }
                 if (discarded > 0) {
-                    log.info("{}: too old records discarded: count={}", stagingObject.getObjectUri(), discarded);
+                    log.info("{}: too past/future records discarded: count={}", stagingObject.getObjectUri(), discarded);
                 }
             }
 
@@ -119,7 +117,6 @@ public class ParquetConverter implements StagingObjectHandler {
             for (Entry<LocalDate, Path> entry: partitions.entrySet()) {
                 LocalDate dt = entry.getKey();
                 File file = entry.getValue().toFile();
-                LocalDateTime now = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
                 PrismPartition partition = this.partitionMapper.createPartitionIfNotExists(table.getId(), dt);
                 long contentLength = file.length();
                 PrismSmallObject smallObject = this.smallObjectMapper.findOrCreateByParams(stagingObject.getId(), partition.getId(), now, contentLength);
@@ -136,6 +133,15 @@ public class ParquetConverter implements StagingObjectHandler {
         } catch (IOException ex) {
             throw new RuntimeException("Encountered an error in converting JSONL to Parquet", ex);
         }
+    }
+
+    static final long ACCEPTABLE_PAST_DAYS = 21;
+    static final long ACCEPTABLE_FUTURE_DAYS = 14;
+
+    static boolean isAcceptable(LocalDate partitionDate, LocalDateTime now) {
+        LocalDate min = now.minusDays(ACCEPTABLE_PAST_DAYS).toLocalDate();
+        LocalDate max = now.plusDays(ACCEPTABLE_FUTURE_DAYS).toLocalDate();
+        return min.compareTo(partitionDate) <= 0 && partitionDate.compareTo(max) <= 0;
     }
 
     static final long MERGEABLE_DELAY_DAYS = 14;

--- a/stream/src/test/java/com/cookpad/prism/stream/ParquetConverterTest.java
+++ b/stream/src/test/java/com/cookpad/prism/stream/ParquetConverterTest.java
@@ -120,39 +120,39 @@ public class ParquetConverterTest {
     }
 
     @Test
-    public void testIsAcceptableDelay() throws Exception {
+    public void testIsMergeableDelay() throws Exception {
         var now = LocalDateTime.of(2020,6,20,0,0);
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,3), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,4), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,5), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,19), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,20), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,21), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,22), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,3), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,4), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,5), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,19), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,20), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,21), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,22), now));
 
         now = LocalDateTime.of(2020,6,20,0,59);
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,3), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,4), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,5), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,3), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,4), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,5), now));
 
         now = LocalDateTime.of(2020,6,20,1,0);
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,3), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,4), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,5), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,3), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,4), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,5), now));
 
         now = LocalDateTime.of(2020,6,20,22,0);
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,21), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,22), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,23), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,21), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,22), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,23), now));
 
         now = LocalDateTime.of(2020,6,20,22,59);
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,21), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,22), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,23), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,21), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,22), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,23), now));
 
         now = LocalDateTime.of(2020,6,20,23,0);
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,21), now));
-        assertTrue(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,22), now));
-        assertFalse(ParquetConverter.isAcceptableDelay(LocalDate.of(2020,6,23), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,21), now));
+        assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,22), now));
+        assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,23), now));
     }
 }

--- a/stream/src/test/java/com/cookpad/prism/stream/ParquetConverterTest.java
+++ b/stream/src/test/java/com/cookpad/prism/stream/ParquetConverterTest.java
@@ -155,4 +155,25 @@ public class ParquetConverterTest {
         assertTrue(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,22), now));
         assertFalse(ParquetConverter.isMergeableDelay(LocalDate.of(2020,6,23), now));
     }
+
+    @Test
+    public void testIsAcceptable() throws Exception {
+        LocalDateTime now = LocalDateTime.of(2022, 9, 9, 0, 0);
+
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 9), now));
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 19), now));
+        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 18), now));
+
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 23), now));
+        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 24), now));
+
+        now = LocalDateTime.of(2022, 9, 9, 23, 59);
+
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 9), now));
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 19), now));
+        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 18), now));
+
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 23), now));
+        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 24), now));
+    }
 }

--- a/stream/src/test/java/com/cookpad/prism/stream/ParquetConverterTest.java
+++ b/stream/src/test/java/com/cookpad/prism/stream/ParquetConverterTest.java
@@ -164,8 +164,8 @@ public class ParquetConverterTest {
         assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 19), now));
         assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 18), now));
 
-        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 23), now));
-        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 24), now));
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 12), now));
+        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 13), now));
 
         now = LocalDateTime.of(2022, 9, 9, 23, 59);
 
@@ -173,7 +173,7 @@ public class ParquetConverterTest {
         assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 19), now));
         assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 8, 18), now));
 
-        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 23), now));
-        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 24), now));
+        assertTrue(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 12), now));
+        assertFalse(ParquetConverter.isAcceptable(LocalDate.of(2022, 9, 13), now));
     }
 }


### PR DESCRIPTION
I'm planning to add date range limit to small object creations. This change is a preparation for prism_small_objects and prism_staging_objects rotation.

# About too past objects
prism-stream currently accepts any staging objects after 2018-01-01 and creates prism_small_objects records and S3 objects. This behavior makes it hard to rotate prism_small_objects and prism_staging_objects.
However, these past records and S3 objects are never used if the acceptable merge limit (15 days and 1 hour) had passed.
So we don't need to create such too past records and S3 objects.

# About too future objects
Future staging object is sometimes created by some reasons. This makes it a little hard to rotate prism_small_objects and prism_staging_objects by slowing down some queries in use.
I'm thinking of what the appropriate threshold should be.