### PR TITLE
Add PrismObjectType tag to S3 objects

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 configurations.all {
     exclude module: 'slf4j-log4j12'
     exclude module: 'log4j'
+    exclude module: 'slf4j-reload4j'
 }
 
 docker {

--- a/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
+++ b/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -41,11 +42,10 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     }
 
     private PutObjectRequest createPutRequestWithTag(String bucketName, String key, File content, PrismObjectType prismObjectType) {
-        PutObjectRequest putRequest = new PutObjectRequest(bucketName, key, content);
-        List<Tag> tags = new ArrayList<>();
-        tags.add(new Tag(PRISM_OBJECT_TYPE_KEY, prismObjectType.getTagValue()));
-        putRequest.setTagging(new ObjectTagging(tags));
-        return putRequest;
+        return new PutObjectRequest(bucketName, key, content)
+        .withTagging(new ObjectTagging(List.of(
+            new Tag(PRISM_OBJECT_TYPE_KEY, prismObjectType.getTagValue())
+        )));
     }
 
     @Override

--- a/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
+++ b/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
@@ -26,17 +26,24 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     private static final String PRISM_OBJECT_TYPE_KEY = "PrismObjectType";
-    private static final String MERGED_OBJECT_TYPE = "merged";
-    private static final String LIVE_OBJECT_TYPE = "live";
-    private static final String DELAYED_OBJECT_TYPE = "delayed";
 
     final private AmazonS3 s3;
     final private PrismTableLocator locator;
 
-    private PutObjectRequest createPutRequestWithTag(String bucketName, String key, File content, String tagValue) {
+    private enum PrismObjectType {
+        MERGED,
+        LIVE,
+        DELAYED;
+
+        public String getTagValue() {
+            return this.name().toLowerCase();
+        }
+    }
+
+    private PutObjectRequest createPutRequestWithTag(String bucketName, String key, File content, PrismObjectType prismObjectType) {
         PutObjectRequest putRequest = new PutObjectRequest(bucketName, key, content);
         List<Tag> tags = new ArrayList<>();
-        tags.add(new Tag(PRISM_OBJECT_TYPE_KEY, tagValue));
+        tags.add(new Tag(PRISM_OBJECT_TYPE_KEY, prismObjectType.getTagValue()));
         putRequest.setTagging(new ObjectTagging(tags));
         return putRequest;
     }
@@ -64,7 +71,7 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
         log.info("PutObject (live) key={}", key);
 
         PutObjectRequest putRequest = createPutRequestWithTag(
-            locator.getBucketName(), key, content, LIVE_OBJECT_TYPE);
+            locator.getBucketName(), key, content, PrismObjectType.LIVE);
 
         s3.putObject(putRequest);
         return key;
@@ -93,7 +100,7 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
         log.info("PutObject (delayed) key={}", key);
 
         PutObjectRequest putRequest = createPutRequestWithTag(
-            locator.getBucketName(), key, content, DELAYED_OBJECT_TYPE);
+            locator.getBucketName(), key, content, PrismObjectType.DELAYED);
 
         s3.putObject(putRequest);
         return key;
@@ -122,7 +129,7 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
         log.info("PutObject (merged) key={}", key);
 
         PutObjectRequest putRequest = createPutRequestWithTag(
-            locator.getBucketName(), key, content, MERGED_OBJECT_TYPE);
+            locator.getBucketName(), key, content, PrismObjectType.MERGED);
 
         s3.putObject(putRequest);
         return key;

--- a/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
+++ b/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
@@ -67,11 +67,7 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     public String putLiveObjectFile(LocalDate dt, long objectId, File content) {
         String key = locator.getLiveObjectKey(dt, objectId);
         log.info("PutObject (live) key={}", key);
-
-        PutObjectRequest putRequest = createPutRequestWithTag(
-            locator.getBucketName(), key, content, PrismObjectType.LIVE);
-
-        s3.putObject(putRequest);
+        s3.putObject(createPutRequestWithTag(locator.getBucketName(), key, content, PrismObjectType.LIVE));
         return key;
     }
 
@@ -96,11 +92,7 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     public String putDelayedObjectFile(LocalDate dt, long objectId, File content) {
         String key = locator.getDelayedObjectKey(dt, objectId);
         log.info("PutObject (delayed) key={}", key);
-
-        PutObjectRequest putRequest = createPutRequestWithTag(
-            locator.getBucketName(), key, content, PrismObjectType.DELAYED);
-
-        s3.putObject(putRequest);
+        s3.putObject(createPutRequestWithTag(locator.getBucketName(), key, content, PrismObjectType.DELAYED));
         return key;
     }
 
@@ -125,11 +117,7 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     public String putMergedObjectFile(LocalDate dt, long lowerBound, long upperBound, File content) {
         String key = locator.getMergedObjectKey(dt, lowerBound, upperBound);
         log.info("PutObject (merged) key={}", key);
-
-        PutObjectRequest putRequest = createPutRequestWithTag(
-            locator.getBucketName(), key, content, PrismObjectType.MERGED);
-
-        s3.putObject(putRequest);
+        s3.putObject(createPutRequestWithTag(locator.getBucketName(), key, content, PrismObjectType.MERGED));
         return key;
     }
 

--- a/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
+++ b/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
@@ -9,10 +9,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.Tag;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,8 +25,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
+    private static final String PRISM_OBJECT_TYPE_KEY = "PrismObjectType";
+    private static final String MERGED_OBJECT_TYPE = "merged";
+    private static final String LIVE_OBJECT_TYPE = "live";
+    private static final String DELAYED_OBJECT_TYPE = "delayed";
+
     final private AmazonS3 s3;
     final private PrismTableLocator locator;
+
+    private PutObjectRequest createPutRequestWithTag(String bucketName, String key, File content, String tagValue) {
+        PutObjectRequest putRequest = new PutObjectRequest(bucketName, key, content);
+        List<Tag> tags = new ArrayList<>();
+        tags.add(new Tag(PRISM_OBJECT_TYPE_KEY, tagValue));
+        putRequest.setTagging(new ObjectTagging(tags));
+        return putRequest;
+    }
 
     @Override
     public InputStream getLiveObject(LocalDate dt, long objectId) {
@@ -44,7 +62,11 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     public String putLiveObjectFile(LocalDate dt, long objectId, File content) {
         String key = locator.getLiveObjectKey(dt, objectId);
         log.info("PutObject (live) key={}", key);
-        s3.putObject(locator.getBucketName(), key, content);
+
+        PutObjectRequest putRequest = createPutRequestWithTag(
+            locator.getBucketName(), key, content, LIVE_OBJECT_TYPE);
+
+        s3.putObject(putRequest);
         return key;
     }
 
@@ -69,7 +91,11 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     public String putDelayedObjectFile(LocalDate dt, long objectId, File content) {
         String key = locator.getDelayedObjectKey(dt, objectId);
         log.info("PutObject (delayed) key={}", key);
-        s3.putObject(locator.getBucketName(), key, content);
+
+        PutObjectRequest putRequest = createPutRequestWithTag(
+            locator.getBucketName(), key, content, DELAYED_OBJECT_TYPE);
+
+        s3.putObject(putRequest);
         return key;
     }
 
@@ -94,7 +120,11 @@ public class PrismObjectStore implements SmallObjectStore, MergedObjectStore {
     public String putMergedObjectFile(LocalDate dt, long lowerBound, long upperBound, File content) {
         String key = locator.getMergedObjectKey(dt, lowerBound, upperBound);
         log.info("PutObject (merged) key={}", key);
-        s3.putObject(locator.getBucketName(), key, content);
+
+        PutObjectRequest putRequest = createPutRequestWithTag(
+            locator.getBucketName(), key, content, MERGED_OBJECT_TYPE);
+
+        s3.putObject(putRequest);
         return key;
     }
 

--- a/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
+++ b/shared/src/main/java/com/cookpad/prism/objectstore/PrismObjectStore.java
@@ -9,8 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import com.amazonaws.services.s3.AmazonS3;

--- a/shared/src/test/java/com/cookpad/prism/objectstore/PrismObjectStoreTest.java
+++ b/shared/src/test/java/com/cookpad/prism/objectstore/PrismObjectStoreTest.java
@@ -1,0 +1,61 @@
+package com.cookpad.prism.objectstore;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectTagging;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.Tag;
+
+public class PrismObjectStoreTest {
+    private AmazonS3 s3;
+    private PrismTableLocator locator;
+    private PrismObjectStore store;
+
+    @BeforeEach
+    void setUp() {
+        s3 = mock(AmazonS3.class);
+        locator = mock(PrismTableLocator.class);
+        store = new PrismObjectStore(s3, locator);
+    }
+
+    @Test
+    void putLiveObjectFile_shouldCreateRequestWithCorrectTag() {
+        // Arrange
+        LocalDate testDate = LocalDate.of(2025, 1, 1);
+        long objectId = 100;
+        File testFile = mock(File.class);
+        String bucketName = "test-bucket";
+        String testKey = "test-key";
+
+        when(locator.getBucketName()).thenReturn(bucketName);
+        when(locator.getLiveObjectKey(testDate, objectId)).thenReturn(testKey);
+
+        // Act
+        store.putLiveObjectFile(testDate, objectId, testFile);
+
+        // Assert
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3).putObject(requestCaptor.capture());
+
+        PutObjectRequest capturedRequest = requestCaptor.getValue();
+        assertEquals(bucketName, capturedRequest.getBucketName());
+        assertEquals(testKey, capturedRequest.getKey());
+        assertEquals(testFile, capturedRequest.getFile());
+
+        ObjectTagging tagging = capturedRequest.getTagging();
+        List<Tag> tags = tagging.getTagSet();
+        assertEquals(1, tags.size());
+        assertEquals("PrismObjectType", tags.get(0).getKey());
+        assertEquals("live", tags.get(0).getValue());
+    }
+}


### PR DESCRIPTION
What:
This changes add PrismObjectType tag for each object type, live/delayed/merged to S3 objects.

Why:
To apply S3 lifecycle rules that targets each types.

For example, I'm planning to move merged objects to Amazon S3 Intelligent-Tiering storage class using lifecycle rule.